### PR TITLE
Update maxConcurrentRun default to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,13 @@ geSaLaKaCuLa({
 
 > Sauce Labs provide free accounts for open source project with
 > - Unlimited testing minutes
-> - 3 parallel tests
-> - 3 queued tests
+> - 5 parallel tests
 
 ![giphy](https://cloud.githubusercontent.com/assets/730511/5900580/309f3842-a56b-11e4-8186-a4e5614ec9d4.gif)
 
 Karma is a bit difficult to configure with Sauce Labs. Like there is no "queue" principal, Karma try to connect to all the browsers at the same time. There for when a browser in the Sauce Labs queue will often reach the `browserDisconnectTimeout` and cause the test to fail without actually running them.
 
-**So I came with a simple idea of recursively restarting a karma server with the 3 parallel browsers limit of  Sauce Labs.**
+**So I came with a simple idea of recursively restarting a karma server with the 5 parallel browsers limit of  Sauce Labs.**
 
 Thus, there is not potential `browserDisconnectTimeout` of browser in the Sauce Labs queue...
 
@@ -169,7 +168,7 @@ default :
 {
   configFile: './karma.conf.js',
   customLaunchers: {},
-  maxConcurrentRun : 3
+  maxConcurrentRun : 5
 }
 ```
 

--- a/lib/reKaLa.js
+++ b/lib/reKaLa.js
@@ -7,7 +7,7 @@ var extend = util._extend;
 var OPTIONS_DEFAULTS = {
   configFile: './karma.conf.js',
   customLaunchers: {},
-  maxConcurrentRun : 3
+  maxConcurrentRun : 5
 };
 
 // The "reKaLa" magic spell !! reKaLaaaaaaaaaaaaaaaaaaaa :D


### PR DESCRIPTION
[Open Sauce](https://saucelabs.com/opensauce/) accounts now support 5 Parallel VM's so we can bump the default from 3 to 5:
![screen shot 2015-08-27 at 6 22 45 pm](https://cloud.githubusercontent.com/assets/1290336/9535703/f9f7ed4e-4ce9-11e5-9ed5-2293eb3e88a1.png)

I've tested using `maxConcurrentRun: 5` successfully with an Open Sauce account and things worked wonderfully.